### PR TITLE
Make Windows’ dependencies optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rust:
   - nightly
 sudo: false
 script:
+  - cargo build --verbose --no-default-features
+  - cargo test --verbose --no-default-features
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,14 @@ description = """
 A terminal formatting library
 """
 
-[dependencies]
-winapi = "0.2"
-kernel32-sys = "0.1"
+[features]
+default = ["windows"]
+windows = ["winapi", "kernel32-sys"]
+
+[dependencies.winapi]
+version = "0.2"
+optional = true
+
+[dependencies.kernel32-sys]
+version = "0.1"
+optional = true


### PR DESCRIPTION
Hello,


I’m curious if anybody else is interested in making Windows’ dependencies optional. I personally don’t program for Windows, and it’s very unfortunate to see a lot of unrelated dependencies getting pulled in. Thank you.

Regards,
Ivan