### PR TITLE
Rustfmt term, skip formatting statics in compiled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,9 @@ pub mod terminfo;
 mod win;
 
 /// Alias for stdout terminals.
-pub type StdoutTerminal = Terminal<Output=Stdout> + Send;
+pub type StdoutTerminal = Terminal<Output = Stdout> + Send;
 /// Alias for stderr terminals.
-pub type StderrTerminal = Terminal<Output=Stderr> + Send;
+pub type StderrTerminal = Terminal<Output = Stderr> + Send;
 
 #[cfg(not(windows))]
 /// Return a Terminal wrapping stdout, or None if a terminal couldn't be

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,40 +90,32 @@ pub type StderrTerminal = Terminal<Output=Stderr> + Send;
 /// Return a Terminal wrapping stdout, or None if a terminal couldn't be
 /// opened.
 pub fn stdout() -> Option<Box<StdoutTerminal>> {
-    TerminfoTerminal::new(io::stdout()).map(|t| {
-        Box::new(t) as Box<StdoutTerminal>
-    })
+    TerminfoTerminal::new(io::stdout()).map(|t| Box::new(t) as Box<StdoutTerminal>)
 }
 
 #[cfg(windows)]
 /// Return a Terminal wrapping stdout, or None if a terminal couldn't be
 /// opened.
 pub fn stdout() -> Option<Box<StdoutTerminal>> {
-    TerminfoTerminal::new(io::stdout()).map(|t| {
-        Box::new(t) as Box<StdoutTerminal>
-    }).or_else(|| WinConsole::new(io::stdout()).ok().map(|t| {
-        Box::new(t) as Box<StdoutTerminal>
-    }))
+    TerminfoTerminal::new(io::stdout())
+        .map(|t| Box::new(t) as Box<StdoutTerminal>)
+        .or_else(|| WinConsole::new(io::stdout()).ok().map(|t| Box::new(t) as Box<StdoutTerminal>))
 }
 
 #[cfg(not(windows))]
 /// Return a Terminal wrapping stderr, or None if a terminal couldn't be
 /// opened.
 pub fn stderr() -> Option<Box<StderrTerminal>> {
-    TerminfoTerminal::new(io::stderr()).map(|t| {
-        Box::new(t) as Box<StderrTerminal>
-    })
+    TerminfoTerminal::new(io::stderr()).map(|t| Box::new(t) as Box<StderrTerminal>)
 }
 
 #[cfg(windows)]
 /// Return a Terminal wrapping stderr, or None if a terminal couldn't be
 /// opened.
 pub fn stderr() -> Option<Box<StderrTerminal>> {
-    TerminfoTerminal::new(io::stderr()).map(|t| {
-        Box::new(t) as Box<StderrTerminal>
-    }).or_else(|| WinConsole::new(io::stderr()).ok().map(|t| {
-        Box::new(t) as Box<StderrTerminal>
-    }))
+    TerminfoTerminal::new(io::stderr())
+        .map(|t| Box::new(t) as Box<StderrTerminal>)
+        .or_else(|| WinConsole::new(io::stderr()).ok().map(|t| Box::new(t) as Box<StderrTerminal>))
 }
 
 
@@ -133,23 +125,23 @@ pub mod color {
     /// Number for a terminal color
     pub type Color = u16;
 
-    pub const BLACK:   Color = 0;
-    pub const RED:     Color = 1;
-    pub const GREEN:   Color = 2;
-    pub const YELLOW:  Color = 3;
-    pub const BLUE:    Color = 4;
+    pub const BLACK: Color = 0;
+    pub const RED: Color = 1;
+    pub const GREEN: Color = 2;
+    pub const YELLOW: Color = 3;
+    pub const BLUE: Color = 4;
     pub const MAGENTA: Color = 5;
-    pub const CYAN:    Color = 6;
-    pub const WHITE:   Color = 7;
+    pub const CYAN: Color = 6;
+    pub const WHITE: Color = 7;
 
-    pub const BRIGHT_BLACK:   Color = 8;
-    pub const BRIGHT_RED:     Color = 9;
-    pub const BRIGHT_GREEN:   Color = 10;
-    pub const BRIGHT_YELLOW:  Color = 11;
-    pub const BRIGHT_BLUE:    Color = 12;
+    pub const BRIGHT_BLACK: Color = 8;
+    pub const BRIGHT_RED: Color = 9;
+    pub const BRIGHT_GREEN: Color = 10;
+    pub const BRIGHT_YELLOW: Color = 11;
+    pub const BRIGHT_BLUE: Color = 12;
     pub const BRIGHT_MAGENTA: Color = 13;
-    pub const BRIGHT_CYAN:    Color = 14;
-    pub const BRIGHT_WHITE:   Color = 15;
+    pub const BRIGHT_CYAN: Color = 14;
+    pub const BRIGHT_WHITE: Color = 15;
 }
 
 /// Terminal attributes for use with term.attr().
@@ -178,7 +170,7 @@ pub enum Attr {
     /// Convenience attribute to set the foreground color
     ForegroundColor(color::Color),
     /// Convenience attribute to set the background color
-    BackgroundColor(color::Color)
+    BackgroundColor(color::Color),
 }
 
 /// A terminal with similar capabilities to an ANSI Terminal

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -32,13 +32,13 @@ use self::parm::{expand, Variables, Param};
 #[derive(Debug)]
 pub struct TermInfo {
     /// Names for the terminal
-    pub names: Vec<String> ,
+    pub names: Vec<String>,
     /// Map of capability name to boolean value
     pub bools: HashMap<String, bool>,
     /// Map of capability name to numeric value
     pub numbers: HashMap<String, u16>,
     /// Map of capability name to raw (unexpanded) string
-    pub strings: HashMap<String, Vec<u8> >
+    pub strings: HashMap<String, Vec<u8>>,
 }
 
 /// A terminfo creation error.
@@ -54,7 +54,9 @@ pub enum Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str { "failed to create TermInfo" }
+    fn description(&self) -> &str {
+        "failed to create TermInfo"
+    }
 
     fn cause(&self) -> Option<&error::Error> {
         use self::Error::*;
@@ -94,12 +96,11 @@ impl TermInfo {
 
     /// Create a TermInfo for the named terminal.
     pub fn from_name(name: &str) -> Result<TermInfo, Error> {
-        get_dbpath_for_term(name).ok_or_else(|| {
-            Error::IoError(io::Error::new(io::ErrorKind::NotFound,
-                                          "terminfo file not found"))
-        }).and_then(|p| {
-            TermInfo::from_path(&p)
-        })
+        get_dbpath_for_term(name)
+            .ok_or_else(|| {
+                Error::IoError(io::Error::new(io::ErrorKind::NotFound, "terminfo file not found"))
+            })
+            .and_then(|p| TermInfo::from_path(&p))
     }
 
     /// Parse the given TermInfo.
@@ -108,11 +109,9 @@ impl TermInfo {
     }
     // Keep the metadata small
     fn _from_path(path: &Path) -> Result<TermInfo, Error> {
-        let file = try!(File::open(path).map_err(|e| { Error::IoError(e) }));
+        let file = try!(File::open(path).map_err(|e| Error::IoError(e)));
         let mut reader = BufReader::new(file);
-        parse(&mut reader, false).map_err(|e| {
-            Error::MalformedTerminfo(e)
-        })
+        parse(&mut reader, false).map_err(|e| Error::MalformedTerminfo(e))
     }
 }
 
@@ -128,19 +127,19 @@ pub mod parm;
 
 fn cap_for_attr(attr: Attr) -> &'static str {
     match attr {
-        Attr::Bold               => "bold",
-        Attr::Dim                => "dim",
-        Attr::Italic(true)       => "sitm",
-        Attr::Italic(false)      => "ritm",
-        Attr::Underline(true)    => "smul",
-        Attr::Underline(false)   => "rmul",
-        Attr::Blink              => "blink",
-        Attr::Standout(true)     => "smso",
-        Attr::Standout(false)    => "rmso",
-        Attr::Reverse            => "rev",
-        Attr::Secure             => "invis",
+        Attr::Bold => "bold",
+        Attr::Dim => "dim",
+        Attr::Italic(true) => "sitm",
+        Attr::Italic(false) => "ritm",
+        Attr::Underline(true) => "smul",
+        Attr::Underline(false) => "rmul",
+        Attr::Blink => "blink",
+        Attr::Standout(true) => "smso",
+        Attr::Standout(false) => "rmso",
+        Attr::Reverse => "rev",
+        Attr::Secure => "invis",
         Attr::ForegroundColor(_) => "setaf",
-        Attr::BackgroundColor(_) => "setab"
+        Attr::BackgroundColor(_) => "setab",
     }
 }
 
@@ -180,9 +179,7 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
 
     fn supports_attr(&self, attr: Attr) -> bool {
         match attr {
-            Attr::ForegroundColor(_) | Attr::BackgroundColor(_) => {
-                self.num_colors > 0
-            }
+            Attr::ForegroundColor(_) | Attr::BackgroundColor(_) => self.num_colors > 0,
             _ => {
                 let cap = cap_for_attr(attr);
                 self.ti.strings.get(cap).is_some()
@@ -193,15 +190,16 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
     fn reset(&mut self) -> io::Result<bool> {
         // are there any terminals that have color/attrs and not sgr0?
         // Try falling back to sgr, then op
-        let cmd = match [
-            "sg0", "sgr", "op"
-        ].iter().filter_map(|cap| {
-            self.ti.strings.get(*cap)
-        }).next() {
-            Some(op) => match expand(&op, &[], &mut Variables::new()) {
-                Ok(cmd) => cmd,
-                Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e))
-            },
+        let cmd = match ["sg0", "sgr", "op"]
+                            .iter()
+                            .filter_map(|cap| self.ti.strings.get(*cap))
+                            .next() {
+            Some(op) => {
+                match expand(&op, &[], &mut Variables::new()) {
+                    Ok(cmd) => cmd,
+                    Err(e) => return Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+                }
+            }
             None => return Ok(false),
         };
         self.out.write_all(&cmd).and(Ok(true))
@@ -219,20 +217,30 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
         self.apply_cap("cr", &[])
     }
 
-    fn get_ref<'a>(&'a self) -> &'a T { &self.out }
+    fn get_ref<'a>(&'a self) -> &'a T {
+        &self.out
+    }
 
-    fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.out }
+    fn get_mut<'a>(&'a mut self) -> &'a mut T {
+        &mut self.out
+    }
 
-    fn into_inner(self) -> T where Self: Sized { self.out }
+    fn into_inner(self) -> T
+        where Self: Sized
+    {
+        self.out
+    }
 }
 
 impl<T: Write+Send> TerminfoTerminal<T> {
     /// Create a new TerminfoTerminal with the given TermInfo and Write.
     pub fn new_with_terminfo(out: T, terminfo: TermInfo) -> TerminfoTerminal<T> {
-        let nc = if terminfo.strings.contains_key("setaf")
-                 && terminfo.strings.contains_key("setab") {
-                     terminfo.numbers.get("colors").map_or(0, |&n| n)
-                 } else { 0 };
+        let nc = if terminfo.strings.contains_key("setaf") &&
+                    terminfo.strings.contains_key("setab") {
+            terminfo.numbers.get("colors").map_or(0, |&n| n)
+        } else {
+            0
+        };
 
         TerminfoTerminal {
             out: out,
@@ -250,17 +258,21 @@ impl<T: Write+Send> TerminfoTerminal<T> {
 
     fn dim_if_necessary(&self, color: color::Color) -> color::Color {
         if color >= self.num_colors && color >= 8 && color < 16 {
-            color-8
-        } else { color }
+            color - 8
+        } else {
+            color
+        }
     }
 
     fn apply_cap(&mut self, cmd: &str, params: &[Param]) -> io::Result<bool> {
         match self.ti.strings.get(cmd) {
-            Some(cmd) => match expand(&cmd, params, &mut Variables::new()) {
-                Ok(s) => self.out.write_all(&s).and(Ok(true)),
-                Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
-            },
-            None => Ok(false)
+            Some(cmd) => {
+                match expand(&cmd, params, &mut Variables::new()) {
+                    Ok(s) => self.out.write_all(&s).and(Ok(true)),
+                    Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, e)),
+                }
+            }
+            None => Ok(false),
         }
     }
 }

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -151,7 +151,7 @@ pub struct TerminfoTerminal<T> {
     ti: TermInfo,
 }
 
-impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
+impl<T: Write + Send> Terminal for TerminfoTerminal<T> {
     type Output = T;
     fn fg(&mut self, color: color::Color) -> io::Result<bool> {
         let color = self.dim_if_necessary(color);
@@ -232,7 +232,7 @@ impl<T: Write+Send> Terminal for TerminfoTerminal<T> {
     }
 }
 
-impl<T: Write+Send> TerminfoTerminal<T> {
+impl<T: Write + Send> TerminfoTerminal<T> {
     /// Create a new TerminfoTerminal with the given TermInfo and Write.
     pub fn new_with_terminfo(out: T, terminfo: TermInfo) -> TerminfoTerminal<T> {
         let nc = if terminfo.strings.contains_key("setaf") &&

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -61,14 +61,18 @@ impl Variables {
     /// Return a new zero-initialized Variables
     pub fn new() -> Variables {
         Variables {
-            sta: [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0)],
-            dyn: [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                  Number(0), Number(0), Number(0), Number(0), Number(0)],
+            sta: [
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0)
+            ],
+            dyn: [
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                Number(0), Number(0), Number(0), Number(0), Number(0)
+            ],
         }
     }
 }
@@ -91,8 +95,10 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<
     let mut stack: Vec<Param> = Vec::new();
 
     // Copy parameters into a local vector for mutability
-    let mut mparams = [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
-                       Number(0), Number(0), Number(0)];
+    let mut mparams = [
+    	Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+        Number(0), Number(0), Number(0)
+    ];
     for (dst, src) in mparams.iter_mut().zip(params.iter()) {
         *dst = (*src).clone();
     }

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -31,14 +31,14 @@ enum States {
     SeekIfElse(usize),
     SeekIfElsePercent(usize),
     SeekIfEnd(usize),
-    SeekIfEndPercent(usize)
+    SeekIfEndPercent(usize),
 }
 
 #[derive(Copy, PartialEq, Clone)]
 enum FormatState {
     FormatStateFlags,
     FormatStateWidth,
-    FormatStatePrecision
+    FormatStatePrecision,
 }
 
 /// Types of parameters a capability can use
@@ -46,7 +46,7 @@ enum FormatState {
 #[derive(Clone)]
 pub enum Param {
     Words(String),
-    Number(i32)
+    Number(i32),
 }
 
 /// Container for static and dynamic variable arrays
@@ -54,29 +54,21 @@ pub struct Variables {
     /// Static variables A-Z
     sta: [Param; 26],
     /// Dynamic variables a-z
-    dyn: [Param; 26]
+    dyn: [Param; 26],
 }
 
 impl Variables {
     /// Return a new zero-initialized Variables
     pub fn new() -> Variables {
         Variables {
-            sta: [
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0),
-            ],
-            dyn: [
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0), Number(0), Number(0), Number(0), Number(0),
-                Number(0),
-            ],
+            sta: [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                  Number(0), Number(0), Number(0), Number(0), Number(0)],
+            dyn: [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                  Number(0), Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                  Number(0), Number(0), Number(0), Number(0), Number(0)],
         }
     }
 }
@@ -90,8 +82,7 @@ impl Variables {
 ///
 /// To be compatible with ncurses, `vars` should be the same between calls to `expand` for
 /// multiple capabilities for the same terminal.
-pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
-    -> Result<Vec<u8> , String> {
+pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables) -> Result<Vec<u8>, String> {
     let mut state = Nothing;
 
     // expanded cap will only rarely be larger than the cap itself
@@ -100,10 +91,8 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
     let mut stack: Vec<Param> = Vec::new();
 
     // Copy parameters into a local vector for mutability
-    let mut mparams = [
-        Number(0), Number(0), Number(0), Number(0), Number(0),
-        Number(0), Number(0), Number(0), Number(0),
-    ];
+    let mut mparams = [Number(0), Number(0), Number(0), Number(0), Number(0), Number(0),
+                       Number(0), Number(0), Number(0)];
     for (dst, src) in mparams.iter_mut().zip(params.iter()) {
         *dst = (*src).clone();
     }
@@ -118,80 +107,115 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 } else {
                     output.push(c);
                 }
-            },
+            }
             Percent => {
                 match cur {
-                    '%' => { output.push(c); state = Nothing },
-                    'c' => match stack.pop() {
-                        // if c is 0, use 0200 (128) for ncurses compatibility
-                        Some(Number(0)) => output.push(128u8),
-                        // Don't check bounds. ncurses just casts and truncates.
-                        Some(Number(c)) => output.push(c as u8),
-                        Some(_) => return Err("a non-char was used with %c".to_string()),
-                        None => return Err("stack is empty".to_string()),
-                    },
+                    '%' => {
+                        output.push(c);
+                        state = Nothing
+                    }
+                    'c' => {
+                        match stack.pop() {
+                            // if c is 0, use 0200 (128) for ncurses compatibility
+                            Some(Number(0)) => output.push(128u8),
+                            // Don't check bounds. ncurses just casts and truncates.
+                            Some(Number(c)) => output.push(c as u8),
+                            Some(_) => return Err("a non-char was used with %c".to_string()),
+                            None => return Err("stack is empty".to_string()),
+                        }
+                    }
                     'p' => state = PushParam,
                     'P' => state = SetVar,
                     'g' => state = GetVar,
                     '\'' => state = CharConstant,
                     '{' => state = IntConstant(0),
-                    'l' => match stack.pop() {
-                        Some(Words(s)) => stack.push(Number(s.len() as i32)),
-                        Some(_) => return Err("a non-str was used with %l".to_string()),
-                        None => return Err("stack is empty".to_string()) 
-                    },
-                    '+'|'-'|'/'|'*'|'^'|'&'|'|'|'m' => match (stack.pop(), stack.pop()) {
-                        (Some(Number(y)), Some(Number(x))) => stack.push(Number(match cur {
-                            '+' => x + y,
-                            '-' => x - y,
-                            '*' => x * y,
-                            '/' => x / y,
-                            '|' => x | y,
-                            '&' => x & y,
-                            '^' => x ^ y,
-                            'm' => x % y,
-                            _ => unreachable!("All cases handled"),
-                        })),
-                        (Some(_), Some(_)) => return Err(format!("non-numbers on stack with {}", cur)),
-                        _ => return Err("stack is empty".to_string()),
-                    },
-                    '='|'>'|'<'|'A'|'O' => match (stack.pop(), stack.pop()) {
-                        (Some(Number(y)), Some(Number(x))) => stack.push(Number(if match cur {
-                            '=' => x == y,
-                            '<' => x < y,
-                            '>' => x > y,
-                            'A' => x > 0 && y > 0,
-                            'O' => x > 0 || y > 0,
-                            _ => unreachable!(),
-                        } { 1 } else { 0 })),
-                        (Some(_), Some(_)) => return Err(format!("non-numbers on stack with {}", cur)),
-                        _ => return Err("stack is empty".to_string()),
-                    },
-                    '!'|'~' => match stack.pop() {
-                        Some(Number(x)) => stack.push(Number(match cur {
-                            '!' if x > 0 => 0,
-                            '!' => 1,
-                            '~' => !x,
-                            _ => unreachable!(),
-                        })),
-                        Some(_) => return Err(format!("non-numbers on stack with {}", cur)),
-                        None => return Err("stack is empty".to_string()),
-                    },
-                    'i' => match (&mparams[0], &mparams[1]) {
-                        (&Number(x), &Number(y)) => {
-                            mparams[0] = Number(x+1);
-                            mparams[1] = Number(y+1);
-                        },
-                        (_, _) => return Err("first two params not numbers with %i".to_string())
-                    },
+                    'l' => {
+                        match stack.pop() {
+                            Some(Words(s)) => stack.push(Number(s.len() as i32)),
+                            Some(_) => return Err("a non-str was used with %l".to_string()),
+                            None => return Err("stack is empty".to_string()),
+                        }
+                    }
+                    '+' | '-' | '/' | '*' | '^' | '&' | '|' | 'm' => {
+                        match (stack.pop(), stack.pop()) {
+                            (Some(Number(y)), Some(Number(x))) => {
+                                stack.push(Number(match cur {
+                                    '+' => x + y,
+                                    '-' => x - y,
+                                    '*' => x * y,
+                                    '/' => x / y,
+                                    '|' => x | y,
+                                    '&' => x & y,
+                                    '^' => x ^ y,
+                                    'm' => x % y,
+                                    _ => unreachable!("All cases handled"),
+                                }))
+                            }
+                            (Some(_), Some(_)) => {
+                                return Err(format!("non-numbers on stack with {}", cur))
+                            }
+                            _ => return Err("stack is empty".to_string()),
+                        }
+                    }
+                    '=' | '>' | '<' | 'A' | 'O' => {
+                        match (stack.pop(), stack.pop()) {
+                            (Some(Number(y)), Some(Number(x))) => {
+                                stack.push(Number(if match cur {
+                                    '=' => x == y,
+                                    '<' => x < y,
+                                    '>' => x > y,
+                                    'A' => x > 0 && y > 0,
+                                    'O' => x > 0 || y > 0,
+                                    _ => unreachable!(),
+                                } {
+                                    1
+                                } else {
+                                    0
+                                }))
+                            }
+                            (Some(_), Some(_)) => {
+                                return Err(format!("non-numbers on stack with {}", cur))
+                            }
+                            _ => return Err("stack is empty".to_string()),
+                        }
+                    }
+                    '!' | '~' => {
+                        match stack.pop() {
+                            Some(Number(x)) => {
+                                stack.push(Number(match cur {
+                                    '!' if x > 0 => 0,
+                                    '!' => 1,
+                                    '~' => !x,
+                                    _ => unreachable!(),
+                                }))
+                            }
+                            Some(_) => return Err(format!("non-numbers on stack with {}", cur)),
+                            None => return Err("stack is empty".to_string()),
+                        }
+                    }
+                    'i' => {
+                        match (&mparams[0], &mparams[1]) {
+                            (&Number(x), &Number(y)) => {
+                                mparams[0] = Number(x + 1);
+                                mparams[1] = Number(y + 1);
+                            }
+                            (_, _) => {
+                                return Err("first two params not numbers with %i".to_string())
+                            }
+                        }
+                    }
 
                     // printf-style support for %doxXs
-                    'd'|'o'|'x'|'X'|'s' => if let Some(arg) = stack.pop() {
-                        let flags = Flags::new();
-                        let res = try!(format(arg, FormatOp::from_char(cur), flags));
-                        output.extend(res.iter().map(|x| *x));
-                    } else { return Err("stack is empty".to_string()) },
-                    ':'|'#'|' '|'.'|'0'...'9' => {
+                    'd' | 'o' | 'x' | 'X' | 's' => {
+                        if let Some(arg) = stack.pop() {
+                            let flags = Flags::new();
+                            let res = try!(format(arg, FormatOp::from_char(cur), flags));
+                            output.extend(res.iter().map(|x| *x));
+                        } else {
+                            return Err("stack is empty".to_string());
+                        }
+                    }
+                    ':' | '#' | ' ' | '.' | '0'...'9' => {
                         let mut flags = Flags::new();
                         let mut fstate = FormatStateFlags;
                         match cur {
@@ -203,46 +227,55 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                                 flags.width = cur as usize - '0' as usize;
                                 fstate = FormatStateWidth;
                             }
-                            _ => unreachable!()
+                            _ => unreachable!(),
                         }
                         state = FormatPattern(flags, fstate);
                     }
 
                     // conditionals
                     '?' => (),
-                    't' => match stack.pop() {
-                        Some(Number(0)) => state = SeekIfElse(0),
-                        Some(Number(_)) => (),
-                        Some(_) => return Err("non-number on stack with conditional".to_string()),
-                        None => return Err("stack is empty".to_string()),
-                    },
+                    't' => {
+                        match stack.pop() {
+                            Some(Number(0)) => state = SeekIfElse(0),
+                            Some(Number(_)) => (),
+                            Some(_) => {
+                                return Err("non-number on stack with conditional".to_string())
+                            }
+                            None => return Err("stack is empty".to_string()),
+                        }
+                    }
                     'e' => state = SeekIfEnd(0),
                     ';' => (),
                     _ => return Err(format!("unrecognized format option {}", cur)),
                 }
-            },
+            }
             PushParam => {
                 // params are 1-indexed
                 stack.push(mparams[match cur.to_digit(10) {
-                    Some(d) => d as usize - 1,
-                    None => return Err("bad param number".to_string())
-                }].clone());
-            },
+                               Some(d) => d as usize - 1,
+                               None => return Err("bad param number".to_string()),
+                           }]
+                           .clone());
+            }
             SetVar => {
                 if cur >= 'A' && cur <= 'Z' {
                     if let Some(arg) = stack.pop() {
                         let idx = (cur as u8) - b'A';
                         vars.sta[idx as usize] = arg;
-                    } else { return Err("stack is empty".to_string()) }
+                    } else {
+                        return Err("stack is empty".to_string());
+                    }
                 } else if cur >= 'a' && cur <= 'z' {
                     if let Some(arg) = stack.pop() {
                         let idx = (cur as u8) - b'a';
                         vars.dyn[idx as usize] = arg;
-                    } else { return Err("stack is empty".to_string()) }
+                    } else {
+                        return Err("stack is empty".to_string());
+                    }
                 } else {
                     return Err("bad variable name in %P".to_string());
                 }
-            },
+            }
             GetVar => {
                 if cur >= 'A' && cur <= 'Z' {
                     let idx = (cur as u8) - b'A';
@@ -253,25 +286,27 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                 } else {
                     return Err("bad variable name in %g".to_string());
                 }
-            },
+            }
             CharConstant => {
                 stack.push(Number(c as i32));
                 state = CharClose;
-            },
-            CharClose => if cur != '\'' {
-                return Err("malformed character constant".to_string());
-            },
+            }
+            CharClose => {
+                if cur != '\'' {
+                    return Err("malformed character constant".to_string());
+                }
+            }
             IntConstant(i) => {
                 if cur == '}' {
                     stack.push(Number(i));
                     state = Nothing;
                 } else if let Some(digit) = cur.to_digit(10) {
-                    match i.checked_mul(10).and_then(|i_ten|i_ten.checked_add(digit as i32)) {
+                    match i.checked_mul(10).and_then(|i_ten| i_ten.checked_add(digit as i32)) {
                         Some(i) => {
                             state = IntConstant(i);
                             old_state = Nothing;
                         }
-                        None => return Err("int constant too large".to_string())
+                        None => return Err("int constant too large".to_string()),
                     }
                 } else {
                     return Err("bad int constant".to_string());
@@ -280,47 +315,53 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
             FormatPattern(ref mut flags, ref mut fstate) => {
                 old_state = Nothing;
                 match (*fstate, cur) {
-                    (_,'d')|(_,'o')|(_,'x')|(_,'X')|(_,'s') => if let Some(arg) = stack.pop() {
-                        let res = try!(format(arg, FormatOp::from_char(cur), *flags));
-                        output.extend(res.iter().map(|x| *x));
-                        // will cause state to go to Nothing
-                        old_state = FormatPattern(*flags, *fstate);
-                    } else { return Err("stack is empty".to_string()) },
-                    (FormatStateFlags,'#') => {
+                    (_, 'd') | (_, 'o') | (_, 'x') | (_, 'X') | (_, 's') => {
+                        if let Some(arg) = stack.pop() {
+                            let res = try!(format(arg, FormatOp::from_char(cur), *flags));
+                            output.extend(res.iter().map(|x| *x));
+                            // will cause state to go to Nothing
+                            old_state = FormatPattern(*flags, *fstate);
+                        } else {
+                            return Err("stack is empty".to_string());
+                        }
+                    }
+                    (FormatStateFlags, '#') => {
                         flags.alternate = true;
                     }
-                    (FormatStateFlags,'-') => {
+                    (FormatStateFlags, '-') => {
                         flags.left = true;
                     }
-                    (FormatStateFlags,'+') => {
+                    (FormatStateFlags, '+') => {
                         flags.sign = true;
                     }
-                    (FormatStateFlags,' ') => {
+                    (FormatStateFlags, ' ') => {
                         flags.space = true;
                     }
-                    (FormatStateFlags,'0'...'9') => {
+                    (FormatStateFlags, '0'...'9') => {
                         flags.width = cur as usize - '0' as usize;
                         *fstate = FormatStateWidth;
                     }
-                    (FormatStateFlags,'.') => {
+                    (FormatStateFlags, '.') => {
                         *fstate = FormatStatePrecision;
                     }
-                    (FormatStateWidth,'0'...'9') => {
+                    (FormatStateWidth, '0'...'9') => {
                         let old = flags.width;
                         flags.width = flags.width * 10 + (cur as usize - '0' as usize);
-                        if flags.width < old { return Err("format width overflow".to_string()) }
+                        if flags.width < old {
+                            return Err("format width overflow".to_string());
+                        }
                     }
-                    (FormatStateWidth,'.') => {
+                    (FormatStateWidth, '.') => {
                         *fstate = FormatStatePrecision;
                     }
-                    (FormatStatePrecision,'0'...'9') => {
+                    (FormatStatePrecision, '0'...'9') => {
                         let old = flags.precision;
                         flags.precision = flags.precision * 10 + (cur as usize - '0' as usize);
                         if flags.precision < old {
-                            return Err("format precision overflow".to_string())
+                            return Err("format precision overflow".to_string());
                         }
                     }
-                    _ => return Err("invalid format specifier".to_string())
+                    _ => return Err("invalid format specifier".to_string()),
                 }
             }
             SeekIfElse(level) => {
@@ -334,12 +375,12 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     if level == 0 {
                         state = Nothing;
                     } else {
-                        state = SeekIfElse(level-1);
+                        state = SeekIfElse(level - 1);
                     }
                 } else if cur == 'e' && level == 0 {
                     state = Nothing;
                 } else if cur == '?' {
-                    state = SeekIfElse(level+1);
+                    state = SeekIfElse(level + 1);
                 } else {
                     state = SeekIfElse(level);
                 }
@@ -355,10 +396,10 @@ pub fn expand(cap: &[u8], params: &[Param], vars: &mut Variables)
                     if level == 0 {
                         state = Nothing;
                     } else {
-                        state = SeekIfEnd(level-1);
+                        state = SeekIfEnd(level - 1);
                     }
                 } else if cur == '?' {
-                    state = SeekIfEnd(level+1);
+                    state = SeekIfEnd(level + 1);
                 } else {
                     state = SeekIfEnd(level);
                 }
@@ -378,13 +419,19 @@ struct Flags {
     alternate: bool,
     left: bool,
     sign: bool,
-    space: bool
+    space: bool,
 }
 
 impl Flags {
     fn new() -> Flags {
-        Flags{ width: 0, precision: 0, alternate: false,
-               left: false, sign: false, space: false }
+        Flags {
+            width: 0,
+            precision: 0,
+            alternate: false,
+            left: false,
+            sign: false,
+            space: false,
+        }
     }
 }
 
@@ -394,7 +441,7 @@ enum FormatOp {
     FormatOctal,
     FormatHex,
     FormatHEX,
-    FormatString
+    FormatString,
 }
 
 impl FormatOp {
@@ -405,7 +452,7 @@ impl FormatOp {
             'x' => FormatHex,
             'X' => FormatHEX,
             's' => FormatString,
-            _ => panic!("bad FormatOp char")
+            _ => panic!("bad FormatOp char"),
         }
     }
     fn to_char(self) -> char {
@@ -414,59 +461,64 @@ impl FormatOp {
             FormatOctal => 'o',
             FormatHex => 'x',
             FormatHEX => 'X',
-            FormatString => 's'
+            FormatString => 's',
         }
     }
 }
 
-fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8> ,String> {
+fn format(val: Param, op: FormatOp, flags: Flags) -> Result<Vec<u8>, String> {
     let mut s = match val {
-        Number(d) => match op {
-            FormatDigit => {
-                if flags.sign {
-                    format!("{:+01$}", d, flags.precision)
-                } else if d < 0 {
-                    // C doesn't take sign into account in precision calculation.
-                    format!("{:01$}", d, flags.precision + 1)
-                } else if flags.space {
-                    format!(" {:01$}", d, flags.precision)
-                } else {
-                    format!("{:01$}", d, flags.precision)
+        Number(d) => {
+            match op {
+                FormatDigit => {
+                    if flags.sign {
+                        format!("{:+01$}", d, flags.precision)
+                    } else if d < 0 {
+                        // C doesn't take sign into account in precision calculation.
+                        format!("{:01$}", d, flags.precision + 1)
+                    } else if flags.space {
+                        format!(" {:01$}", d, flags.precision)
+                    } else {
+                        format!("{:01$}", d, flags.precision)
+                    }
                 }
-            },
-            FormatOctal => {
-                if flags.alternate {
-                    // Leading octal zero counts against precision.
-                    format!("0{:01$o}", d, flags.precision.saturating_sub(1))
-                } else {
-                    format!("{:01$o}", d, flags.precision)
+                FormatOctal => {
+                    if flags.alternate {
+                        // Leading octal zero counts against precision.
+                        format!("0{:01$o}", d, flags.precision.saturating_sub(1))
+                    } else {
+                        format!("{:01$o}", d, flags.precision)
+                    }
                 }
-            },
-            FormatHex => {
-                if flags.alternate && d != 0 {
-                    format!("0x{:01$x}", d, flags.precision)
-                } else {
-                    format!("{:01$x}", d, flags.precision)
+                FormatHex => {
+                    if flags.alternate && d != 0 {
+                        format!("0x{:01$x}", d, flags.precision)
+                    } else {
+                        format!("{:01$x}", d, flags.precision)
+                    }
                 }
-            },
-            FormatHEX => {
-                if flags.alternate && d != 0 {
-                    format!("0X{:01$X}", d, flags.precision)
-                } else {
-                    format!("{:01$X}", d, flags.precision)
+                FormatHEX => {
+                    if flags.alternate && d != 0 {
+                        format!("0X{:01$X}", d, flags.precision)
+                    } else {
+                        format!("{:01$X}", d, flags.precision)
+                    }
                 }
-            },
-            FormatString => return Err("non-number on stack with %s".to_string())
-        }.into_bytes(),
-        Words(s) => match op {
-            FormatString => {
-                let mut s = s.into_bytes();
-                if flags.precision > 0 && flags.precision < s.len() {
-                    s.truncate(flags.precision);
+                FormatString => return Err("non-number on stack with %s".to_string()),
+            }
+            .into_bytes()
+        }
+        Words(s) => {
+            match op {
+                FormatString => {
+                    let mut s = s.into_bytes();
+                    if flags.precision > 0 && flags.precision < s.len() {
+                        s.truncate(flags.precision);
+                    }
+                    s
                 }
-                s
-            },
-            _ => return Err(format!("non-string on stack with %{}", op.to_char()))
+                _ => return Err(format!("non-string on stack with %{}", op.to_char())),
+            }
         }
     };
     if flags.width > s.len() {
@@ -506,7 +558,8 @@ mod test {
     fn test_op_i() {
         let mut vars = Variables::new();
         assert_eq!(expand(b"%p1%d%p2%d%p3%d%i%p1%d%p2%d%p3%d",
-                          &[Number(1),Number(2),Number(3)], &mut vars),
+                          &[Number(1), Number(2), Number(3)],
+                          &mut vars),
                    Ok("123233".bytes().collect::<Vec<_>>()));
         assert_eq!(expand(b"%p1%d%p2%d%i%p1%d%p2%d", &[], &mut vars),
                    Ok("0011".bytes().collect::<Vec<_>>()));
@@ -516,9 +569,11 @@ mod test {
     fn test_param_stack_failure_conditions() {
         let mut varstruct = Variables::new();
         let vars = &mut varstruct;
-        fn get_res(fmt: &str, cap: &str, params: &[Param], vars: &mut Variables) ->
-            Result<Vec<u8>, String>
-        {
+        fn get_res(fmt: &str,
+                   cap: &str,
+                   params: &[Param],
+                   vars: &mut Variables)
+                   -> Result<Vec<u8>, String> {
             let mut u8v: Vec<_> = fmt.bytes().collect();
             u8v.extend(cap.as_bytes().iter().map(|&b| b));
             expand(&u8v, params, vars)
@@ -528,7 +583,8 @@ mod test {
         for &cap in caps.iter() {
             let res = get_res("", cap, &[], vars);
             assert!(res.is_err(),
-                    "Op {} succeeded incorrectly with 0 stack entries", cap);
+                    "Op {} succeeded incorrectly with 0 stack entries",
+                    cap);
             let p = if cap == "%s" || cap == "%l" {
                 Words("foo".to_string())
             } else {
@@ -536,19 +592,25 @@ mod test {
             };
             let res = get_res("%p1", cap, &[p], vars);
             assert!(res.is_ok(),
-                    "Op {} failed with 1 stack entry: {}", cap, res.err().unwrap());
+                    "Op {} failed with 1 stack entry: {}",
+                    cap,
+                    res.err().unwrap());
         }
         let caps = ["%+", "%-", "%*", "%/", "%m", "%&", "%|", "%A", "%O"];
         for &cap in caps.iter() {
             let res = expand(cap.as_bytes(), &[], vars);
             assert!(res.is_err(),
-                    "Binop {} succeeded incorrectly with 0 stack entries", cap);
+                    "Binop {} succeeded incorrectly with 0 stack entries",
+                    cap);
             let res = get_res("%{1}", cap, &[], vars);
             assert!(res.is_err(),
-                    "Binop {} succeeded incorrectly with 1 stack entry", cap);
+                    "Binop {} succeeded incorrectly with 1 stack entry",
+                    cap);
             let res = get_res("%{1}%{2}", cap, &[], vars);
             assert!(res.is_ok(),
-                    "Binop {} failed with 2 stack entries: {}", cap, res.err().unwrap());
+                    "Binop {} failed with 2 stack entries: {}",
+                    cap,
+                    res.err().unwrap());
         }
     }
 
@@ -564,15 +626,15 @@ mod test {
             let s = format!("%{{1}}%{{2}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
             assert!(res.is_ok(), res.err().unwrap());
-            assert_eq!(res.unwrap(), vec!(b'0' + bs[0]));
+            assert_eq!(res.unwrap(), vec![b'0' + bs[0]]);
             let s = format!("%{{1}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
             assert!(res.is_ok(), res.err().unwrap());
-            assert_eq!(res.unwrap(), vec!(b'0' + bs[1]));
+            assert_eq!(res.unwrap(), vec![b'0' + bs[1]]);
             let s = format!("%{{2}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
             assert!(res.is_ok(), res.err().unwrap());
-            assert_eq!(res.unwrap(), vec!(b'0' + bs[2]));
+            assert_eq!(res.unwrap(), vec![b'0' + bs[2]]);
         }
     }
 
@@ -582,16 +644,13 @@ mod test {
         let s = b"\\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m";
         let res = expand(s, &[Number(1)], &mut vars);
         assert!(res.is_ok(), res.err().unwrap());
-        assert_eq!(res.unwrap(),
-                   "\\E[31m".bytes().collect::<Vec<_>>());
+        assert_eq!(res.unwrap(), "\\E[31m".bytes().collect::<Vec<_>>());
         let res = expand(s, &[Number(8)], &mut vars);
         assert!(res.is_ok(), res.err().unwrap());
-        assert_eq!(res.unwrap(),
-                   "\\E[90m".bytes().collect::<Vec<_>>());
+        assert_eq!(res.unwrap(), "\\E[90m".bytes().collect::<Vec<_>>());
         let res = expand(s, &[Number(42)], &mut vars);
         assert!(res.is_ok(), res.err().unwrap());
-        assert_eq!(res.unwrap(),
-                   "\\E[38;5;42m".bytes().collect::<Vec<_>>());
+        assert_eq!(res.unwrap(), "\\E[38;5;42m".bytes().collect::<Vec<_>>());
     }
 
     #[test]
@@ -602,14 +661,17 @@ mod test {
                           &[Words("foo".to_string()),
                             Words("foo".to_string()),
                             Words("f".to_string()),
-                            Words("foo".to_string())], vars),
+                            Words("foo".to_string())],
+                          vars),
                    Ok("foofoo ffo".bytes().collect::<Vec<_>>()));
         assert_eq!(expand(b"%p1%:-4.2s", &[Words("foo".to_string())], vars),
                    Ok("fo  ".bytes().collect::<Vec<_>>()));
 
         assert_eq!(expand(b"%p1%d%p1%.3d%p1%5d%p1%:+d", &[Number(1)], vars),
                    Ok("1001    1+1".bytes().collect::<Vec<_>>()));
-        assert_eq!(expand(b"%p1%o%p1%#o%p2%6.4x%p2%#6.4X", &[Number(15), Number(27)], vars),
+        assert_eq!(expand(b"%p1%o%p1%#o%p2%6.4x%p2%#6.4X",
+                          &[Number(15), Number(27)],
+                          vars),
                    Ok("17017  001b0X001B".bytes().collect::<Vec<_>>()));
     }
 }

--- a/src/terminfo/parser/compiled.rs
+++ b/src/terminfo/parser/compiled.rs
@@ -173,7 +173,7 @@ fn read_le_u16(r: &mut io::Read) -> io::Result<u16> {
 fn read_byte(r: &mut io::Read) -> io::Result<u8> {
     match r.bytes().next() {
         Some(s) => s,
-        None => Err(io::Error::new(io::ErrorKind::Other, "end of file"))
+        None => Err(io::Error::new(io::ErrorKind::Other, "end of file")),
     }
 }
 
@@ -197,7 +197,8 @@ pub fn parse(file: &mut io::Read, longnames: bool) -> Result<TermInfo, String> {
     let magic = try!(read_le_u16(file));
     if magic != 0x011A {
         return Err(format!("invalid magic number: expected {:x}, found {:x}",
-                           0x011A, magic));
+                           0x011A,
+                           magic));
     }
 
     // According to the spec, these fields must be >= -1 where -1 means that the feature is not
@@ -212,37 +213,33 @@ pub fn parse(file: &mut io::Read, longnames: bool) -> Result<TermInfo, String> {
         }}
     }
 
-    let names_bytes          = read_nonneg!();
-    let bools_bytes          = read_nonneg!();
-    let numbers_count        = read_nonneg!();
+    let names_bytes = read_nonneg!();
+    let bools_bytes = read_nonneg!();
+    let numbers_count = read_nonneg!();
     let string_offsets_count = read_nonneg!();
-    let string_table_bytes   = read_nonneg!();
+    let string_table_bytes = read_nonneg!();
 
     if names_bytes == 0 {
-        return Err("incompatible file: names field must be \
-                    at least 1 byte wide".to_string());
+        return Err("incompatible file: names field must be at least 1 byte wide".to_string());
     }
 
     if bools_bytes > boolnames.len() {
-        return Err("incompatible file: more booleans than \
-                    expected".to_string());
+        return Err("incompatible file: more booleans than expected".to_string());
     }
 
     if numbers_count > numnames.len() {
-        return Err("incompatible file: more numbers than \
-                    expected".to_string());
+        return Err("incompatible file: more numbers than expected".to_string());
     }
 
     if string_offsets_count > stringnames.len() {
-        return Err("incompatible file: more string offsets than \
-                    expected".to_string());
+        return Err("incompatible file: more string offsets than expected".to_string());
     }
 
     // don't read NUL
     let mut bytes = Vec::new();
     try!(file.take((names_bytes - 1) as u64).read_to_end(&mut bytes));
     let names_str = match String::from_utf8(bytes) {
-        Ok(s)  => s,
+        Ok(s) => s,
         Err(_) => return Err("input not utf-8".to_string()),
     };
 
@@ -251,8 +248,7 @@ pub fn parse(file: &mut io::Read, longnames: bool) -> Result<TermInfo, String> {
                                            .collect();
     // consume NUL
     if try!(read_byte(file)) != b'\0' {
-        return Err("incompatible file: missing null terminator \
-                   for names section".to_string());
+        return Err("incompatible file: missing null terminator for names section".to_string());
     }
 
     let bools_map: HashMap<String, bool> = try! {
@@ -276,9 +272,9 @@ pub fn parse(file: &mut io::Read, longnames: bool) -> Result<TermInfo, String> {
     };
 
     let string_map: HashMap<String, Vec<u8>> = if string_offsets_count > 0 {
-        let string_offsets: Vec<u16> = try!((0..string_offsets_count).map(|_| {
-            read_le_u16(file)
-        }).collect());
+        let string_offsets: Vec<u16> = try!((0..string_offsets_count)
+                                                .map(|_| read_le_u16(file))
+                                                .collect());
 
         let mut string_table = Vec::new();
         try!(file.take(string_table_bytes as u64).read_to_end(&mut string_table));
@@ -317,7 +313,7 @@ pub fn parse(file: &mut io::Read, longnames: bool) -> Result<TermInfo, String> {
         names: term_names,
         bools: bools_map,
         numbers: numbers_map,
-        strings: string_map
+        strings: string_map,
     })
 }
 
@@ -333,10 +329,10 @@ pub fn msys_terminfo() -> TermInfo {
     numbers.insert("colors".to_string(), 8u16);
 
     TermInfo {
-        names: vec!("cygwin".to_string()), // msys is a fork of an older cygwin version
+        names: vec!["cygwin".to_string()], // msys is a fork of an older cygwin version
         bools: HashMap::new(),
         numbers: numbers,
-        strings: strings
+        strings: strings,
     }
 }
 

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -21,7 +21,7 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
     let mut dirs_to_search = Vec::new();
     let first_char = match term.chars().next() {
         Some(c) => c,
-        None => return None
+        None => return None,
     };
 
     // Find search directory
@@ -34,13 +34,15 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
                 dirs_to_search.push(homedir)
             }
             match env::var("TERMINFO_DIRS") {
-                Ok(dirs) => for i in dirs.split(':') {
-                    if i == "" {
-                        dirs_to_search.push(PathBuf::from("/usr/share/terminfo"));
-                    } else {
-                        dirs_to_search.push(PathBuf::from(i));
+                Ok(dirs) => {
+                    for i in dirs.split(':') {
+                        if i == "" {
+                            dirs_to_search.push(PathBuf::from("/usr/share/terminfo"));
+                        } else {
+                            dirs_to_search.push(PathBuf::from(i));
+                        }
                     }
-                },
+                }
                 // Found nothing in TERMINFO_DIRS, use the default paths:
                 // According to  /etc/terminfo/README, after looking at
                 // ~/.terminfo, ncurses will search /etc/terminfo, then

--- a/src/win.rs
+++ b/src/win.rs
@@ -95,7 +95,7 @@ fn test_conout() {
     assert!(conout().is_ok())
 }
 
-impl<T: Write+Send> WinConsole<T> {
+impl<T: Write + Send> WinConsole<T> {
     fn apply(&mut self) -> io::Result<()> {
         let out = try!(conout());
         let _unused = self.buf.flush();
@@ -143,7 +143,7 @@ impl<T: Write> Write for WinConsole<T> {
     }
 }
 
-impl<T: Write+Send> Terminal for WinConsole<T> {
+impl<T: Write + Send> Terminal for WinConsole<T> {
     type Output = T;
 
     fn fg(&mut self, color: color::Color) -> io::Result<bool> {

--- a/src/win.rs
+++ b/src/win.rs
@@ -36,15 +36,15 @@ fn color_to_bits(color: color::Color) -> u16 {
     // magic numbers from mingw-w64's wincon.h
 
     let bits = match color % 8 {
-        color::BLACK   => 0,
-        color::BLUE    => 0x1,
-        color::GREEN   => 0x2,
-        color::RED     => 0x4,
-        color::YELLOW  => 0x2 | 0x4,
+        color::BLACK => 0,
+        color::BLUE => 0x1,
+        color::GREEN => 0x2,
+        color::RED => 0x4,
+        color::YELLOW => 0x2 | 0x4,
         color::MAGENTA => 0x1 | 0x4,
-        color::CYAN    => 0x1 | 0x2,
-        color::WHITE   => 0x1 | 0x2 | 0x4,
-        _ => unreachable!()
+        color::CYAN => 0x1 | 0x2,
+        color::WHITE => 0x1 | 0x2 | 0x4,
+        _ => unreachable!(),
     };
 
     if color >= 8 {
@@ -64,7 +64,7 @@ fn bits_to_color(bits: u16) -> color::Color {
         0x5 => color::MAGENTA,
         0x3 => color::CYAN,
         0x7 => color::WHITE,
-        _ => unreachable!()
+        _ => unreachable!(),
     };
 
     color | (bits & 0x8) // copy the hi-intensity bit
@@ -74,15 +74,13 @@ fn bits_to_color(bits: u16) -> color::Color {
 fn conout() -> io::Result<winapi::HANDLE> {
     let name = b"CONOUT$\0";
     let handle = unsafe {
-        kernel32::CreateFileA(
-            name.as_ptr() as *const i8,
-            winapi::GENERIC_READ | winapi::GENERIC_WRITE,
-            winapi::FILE_SHARE_WRITE,
-            ptr::null_mut(),
-            winapi::OPEN_EXISTING,
-            0,
-            ptr::null_mut(),
-        )
+        kernel32::CreateFileA(name.as_ptr() as *const i8,
+                              winapi::GENERIC_READ | winapi::GENERIC_WRITE,
+                              winapi::FILE_SHARE_WRITE,
+                              ptr::null_mut(),
+                              winapi::OPEN_EXISTING,
+                              0,
+                              ptr::null_mut())
     };
     if handle == winapi::INVALID_HANDLE_VALUE {
         Err(io::Error::last_os_error())
@@ -122,7 +120,7 @@ impl<T: Write+Send> WinConsole<T> {
                 fg = bits_to_color(buffer_info.wAttributes);
                 bg = bits_to_color(buffer_info.wAttributes >> 4);
             } else {
-                return Err(io::Error::last_os_error())
+                return Err(io::Error::last_os_error());
             }
         }
         Ok(WinConsole {
@@ -168,13 +166,13 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
                 self.foreground = f;
                 try!(self.apply());
                 Ok(true)
-            },
+            }
             Attr::BackgroundColor(b) => {
                 self.background = b;
                 try!(self.apply());
                 Ok(true)
-            },
-            _ => Ok(false)
+            }
+            _ => Ok(false),
         }
     }
 
@@ -183,7 +181,7 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
         // it to do anything -cmr
         match attr {
             Attr::ForegroundColor(_) | Attr::BackgroundColor(_) => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -201,7 +199,8 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
         unsafe {
             let mut buffer_info = ::std::mem::uninitialized();
             if kernel32::GetConsoleScreenBufferInfo(handle, &mut buffer_info) != 0 {
-                let (x, y) = (buffer_info.dwCursorPosition.X, buffer_info.dwCursorPosition.Y);
+                let (x, y) = (buffer_info.dwCursorPosition.X,
+                              buffer_info.dwCursorPosition.Y);
                 if y == 0 {
                     Ok(false)
                 } else {
@@ -224,17 +223,17 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
         unsafe {
             let mut buffer_info = ::std::mem::uninitialized();
             if kernel32::GetConsoleScreenBufferInfo(handle, &mut buffer_info) == 0 {
-                return Err(io::Error::last_os_error())
+                return Err(io::Error::last_os_error());
             }
             let pos = buffer_info.dwCursorPosition;
             let size = buffer_info.dwSize;
             let num = (size.X - pos.X) as winapi::DWORD;
             let mut written = 0;
             if kernel32::FillConsoleOutputCharacterW(handle, 0, num, pos, &mut written) == 0 {
-                return Err(io::Error::last_os_error())
+                return Err(io::Error::last_os_error());
             }
             if kernel32::FillConsoleOutputAttribute(handle, 0, num, pos, &mut written) == 0 {
-                return Err(io::Error::last_os_error())
+                return Err(io::Error::last_os_error());
             }
             Ok(written != 0)
         }
@@ -246,7 +245,8 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
         unsafe {
             let mut buffer_info = ::std::mem::uninitialized();
             if kernel32::GetConsoleScreenBufferInfo(handle, &mut buffer_info) != 0 {
-                let (x, y) = (buffer_info.dwCursorPosition.X, buffer_info.dwCursorPosition.Y);
+                let (x, y) = (buffer_info.dwCursorPosition.X,
+                              buffer_info.dwCursorPosition.Y);
                 if x == 0 {
                     Ok(false)
                 } else {
@@ -263,9 +263,17 @@ impl<T: Write+Send> Terminal for WinConsole<T> {
         }
     }
 
-    fn get_ref<'a>(&'a self) -> &'a T { &self.buf }
+    fn get_ref<'a>(&'a self) -> &'a T {
+        &self.buf
+    }
 
-    fn get_mut<'a>(&'a mut self) -> &'a mut T { &mut self.buf }
+    fn get_mut<'a>(&'a mut self) -> &'a mut T {
+        &mut self.buf
+    }
 
-    fn into_inner(self) -> T where Self: Sized { self.buf }
+    fn into_inner(self) -> T
+        where Self: Sized
+    {
+        self.buf
+    }
 }


### PR DESCRIPTION
This is the result of running rustfmt over term. This has previously been done over at libterm in rust, but since I've come to learn that that code mirrors term, I thought it could be of use to have the term formatted. All files have been formatted without any further alterations, except for compiled.rs, which has had its statics skipped, due to the whitespace it results in.