### PR TITLE
Fix terminfo database search path

### DIFF
--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -25,36 +25,34 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
     };
 
     // Find search directory
-    match env::var_os("TERMINFO") {
-        Some(dir) => dirs_to_search.push(PathBuf::from(dir)),
-        None => {
-            if let Some(mut homedir) = env::home_dir() {
-                // ncurses compatibility;
-                homedir.push(".terminfo");
-                dirs_to_search.push(homedir)
-            }
-            match env::var("TERMINFO_DIRS") {
-                Ok(dirs) => {
-                    for i in dirs.split(':') {
-                        if i == "" {
-                            dirs_to_search.push(PathBuf::from("/usr/share/terminfo"));
-                        } else {
-                            dirs_to_search.push(PathBuf::from(i));
-                        }
-                    }
-                }
-                // Found nothing in TERMINFO_DIRS, use the default paths:
-                // According to  /etc/terminfo/README, after looking at
-                // ~/.terminfo, ncurses will search /etc/terminfo, then
-                // /lib/terminfo, and eventually /usr/share/terminfo.
-                Err(..) => {
-                    dirs_to_search.push(PathBuf::from("/etc/terminfo"));
-                    dirs_to_search.push(PathBuf::from("/lib/terminfo"));
-                    dirs_to_search.push(PathBuf::from("/usr/share/terminfo"));
-                }
+    if let Some(dir) = env::var_os("TERMINFO") {
+        dirs_to_search.push(PathBuf::from(dir));
+    }
+
+    if let Ok(dirs) = match env::var("TERMINFO_DIRS") {
+        for i in dirs.split(':') {
+            if i == "" {
+                dirs_to_search.push(PathBuf::from("/usr/share/terminfo"));
+            } else {
+                dirs_to_search.push(PathBuf::from(i));
             }
         }
-    };
+    } else {
+        // Found nothing in TERMINFO_DIRS, use the default paths:
+        // According to  /etc/terminfo/README, after looking at
+        // ~/.terminfo, ncurses will search /etc/terminfo, then
+        // /lib/terminfo, and eventually /usr/share/terminfo.
+        // On Haiku the database can be found at /boot/system/data/terminfo
+        if let Some(mut homedir) = env::home_dir() {
+            homedir.push(".terminfo");
+            dirs_to_search.push(homedir)
+        }
+
+        dirs_to_search.push(PathBuf::from("/etc/terminfo"));
+        dirs_to_search.push(PathBuf::from("/lib/terminfo"));
+        dirs_to_search.push(PathBuf::from("/usr/share/terminfo"));
+        dirs_to_search.push(PathBuf::from("/boot/system/data/terminfo"));
+    }
 
     // Look for the terminal in all of the search directories
     for mut p in dirs_to_search {

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -25,6 +25,19 @@ pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
     };
 
     // Find search directory
+    // The terminfo manual says:
+    // 
+    // > If  the  environment  variable  TERMINFO is set, it is interpreted
+    // > as the pathname of a directory containing the compiled description
+    // > you are working on.  Only that directory is searched.
+    //
+    // However, the ncurses manual says:
+    //
+    // > If the environment variable TERMINFO is defined, any program using
+    // > curses checks for a local terminal definition  before  checking in
+    // > the standard place.
+    //
+    // Given that ncurses is the defacto standard, we follow the ncurses manual.
     if let Some(dir) = env::var_os("TERMINFO") {
         dirs_to_search.push(PathBuf::from(dir));
     }


### PR DESCRIPTION
This is more consistent with what every other program does, I happened to have `TERMINFO` set as `/usr/share/terminfo` but had the actual database in `~/.terminfo`, regardless of that every other terminfo/ncurses based software picked up the one in the home correctly.

This just puts the path in `TERMINFO` at the top of the search paths, and moves the home checking to the default search paths section.
