### PR TITLE
Documented function of `delete_line` is more like `clr_eol`

### DIFF
--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -280,7 +280,7 @@ impl<T: Write + Send> Terminal for TerminfoTerminal<T> {
     }
 
     fn delete_line(&mut self) -> Result<()> {
-        self.ti.apply_cap("dl", &[], &mut self.out)
+        self.ti.apply_cap("clr_eol", &[], &mut self.out)
     }
 
     fn carriage_return(&mut self) -> Result<()> {

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -280,7 +280,7 @@ impl<T: Write + Send> Terminal for TerminfoTerminal<T> {
     }
 
     fn delete_line(&mut self) -> Result<()> {
-        self.ti.apply_cap("clr_eol", &[], &mut self.out)
+        self.ti.apply_cap("el", &[], &mut self.out)
     }
 
     fn carriage_return(&mut self) -> Result<()> {


### PR DESCRIPTION
Fixes https://github.com/Stebalien/term/issues/67.

In terminfo as far as I can make out, `dl` means delete the current line and move up from below, whereas your `term.delete_line` is described as deleting to the end of the line.

Possibly this should be fixed in the other direction by adding a new function, and updating the `delete_line` behavior.  But I think the current docstring is accurate on Windows.