### PR TITLE
Implement getting terminal size for windows and linux.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ appveyor = { repository = "Stebalien/term" }
 winapi = "0.2"
 kernel32-sys = "0.2"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default=[]

--- a/examples/kitchen_sink.rs
+++ b/examples/kitchen_sink.rs
@@ -1,0 +1,13 @@
+// An example of the avaiable functionality in term
+
+extern crate term;
+
+fn main() {
+    let mut t = term::stdout().unwrap();
+
+    print!("Dims: ");
+    t.fg(term::color::GREEN).unwrap();
+    print!("{:?}", t.dims().unwrap());
+    t.reset().unwrap();
+    println!();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@
 //!
 //! and this to your crate root:
 //!
-//! ```rust
+//! ```
+//! # #[allow(unused_extern_crates)]
 //! extern crate term;
 //! ```
 //!
@@ -75,6 +76,8 @@ pub mod terminfo;
 
 #[cfg(windows)]
 mod win;
+#[cfg(unix)]
+mod unix;
 
 /// Alias for stdout terminals.
 pub type StdoutTerminal = Terminal<Output = Stdout> + Send;
@@ -166,6 +169,20 @@ pub enum Attr {
     ForegroundColor(color::Color),
     /// Convenience attribute to set the background color
     BackgroundColor(color::Color),
+}
+
+/// A struct representing the number of columns and rows of the terminal, and, if available, the
+/// width and height of the terminal in pixels
+#[derive(Debug, PartialEq, Hash, Eq, Copy, Clone)]
+pub struct Dims {
+    /// The number of rows in the terminal
+    pub rows: u16,
+    /// The number of columns in the terminal
+    pub columns: u16,
+    /// If available, the pixel width of the terminal
+    pub pixel_width: Option<u32>,
+    /// If available, the pixel height of the terminal
+    pub pixel_height: Option<u32>,
 }
 
 /// An error arising from interacting with the terminal.
@@ -389,6 +406,9 @@ pub trait Terminal: Write {
     ///
     /// Returns `Ok(true)` if the deletion code was printed, or `Err(e)` if there was an error.
     fn carriage_return(&mut self) -> Result<()>;
+
+    /// Gets the size of the terminal window, if available
+    fn dims(&self) -> Result<Dims>;
 
     /// Gets an immutable reference to the stream inside
     fn get_ref(&self) -> &Self::Output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub enum Attr {
 
 /// A struct representing the number of columns and rows of the terminal, and, if available, the
 /// width and height of the terminal in pixels
-#[derive(Debug, PartialEq, Hash, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Hash, Eq, Copy, Clone, Default)]
 pub struct Dims {
     /// The number of rows in the terminal
     pub rows: u16,

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -351,7 +351,7 @@ impl<T: Write + AsRawFd> Terminal for TerminfoTerminal<T> {
     }
 
     fn dims(&self) -> Result<Dims> {
-        win_size(self.out.as_raw_fd()).map(|s| s.into()).ok_or(::Error::NotSupported)
+        win_size(self.out.as_raw_fd()).map(|s| s.into())
     }
 
     fn get_ref(&self) -> &T {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -3,17 +3,18 @@ extern crate libc;
 use std::os::unix::io::RawFd;
 use std::mem;
 use Dims;
+use Result;
 
 /// Get the window size from a file descriptor (0 for stdout)
 ///
 /// Option is returned as there is no distinction between errors (all ENOSYS)
-pub fn win_size(fd: RawFd) -> Option<libc::winsize> {
+pub fn win_size(fd: RawFd) -> Result<libc::winsize> {
     unsafe {
         let ws: libc::winsize = mem::uninitialized();
         if libc::ioctl(fd, libc::TIOCGWINSZ, &ws) == 0 {
-            Some(ws)
+            Ok(ws)
         } else {
-            None
+            Err(io::Error::last_os_error().into())
         }
     }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,6 +1,7 @@
 extern crate libc;
 
 use std::os::unix::io::RawFd;
+use std::io;
 use std::mem;
 use Dims;
 use Result;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,30 @@
+extern crate libc;
+
+use std::os::unix::io::RawFd;
+use std::mem;
+use Dims;
+
+/// Get the window size from a file descriptor (0 for stdout)
+///
+/// Option is returned as there is no distinction between errors (all ENOSYS)
+pub fn win_size(fd: RawFd) -> Option<libc::winsize> {
+    unsafe {
+        let ws: libc::winsize = mem::uninitialized();
+        if libc::ioctl(fd, libc::TIOCGWINSZ, &ws) == 0 {
+            Some(ws)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<libc::winsize> for Dims {
+    fn from(sz: libc::winsize) -> Dims {
+        Dims {
+            rows: sz.ws_row as u16,
+            columns: sz.ws_col as u16,
+            pixel_width: Some(sz.ws_xpixel as u32),
+            pixel_height: Some(sz.ws_ypixel as u32),
+        }
+    }
+}

--- a/src/win.rs
+++ b/src/win.rs
@@ -24,6 +24,7 @@ use Error;
 use Result;
 use Terminal;
 use color;
+use Dims;
 
 /// A Terminal implementation which uses the Win32 Console API.
 pub struct WinConsole<T> {
@@ -283,6 +284,10 @@ impl<T: Write + Send> Terminal for WinConsole<T> {
                 Err(io::Error::last_os_error().into())
             }
         }
+    }
+
+    fn dims(&self) -> Result<Dims> {
+        Err(::Error::NotSupported)
     }
 
     fn get_ref<'a>(&'a self) -> &'a T {

--- a/tests/winsize.rs
+++ b/tests/winsize.rs
@@ -1,0 +1,10 @@
+extern crate term;
+
+#[cfg(unix)]
+#[test]
+fn test_winsize() {
+    let t = term::stdout().unwrap();
+    // This makes sure we don't try to provide dims on an incorrect platform, it also may trigger
+    // any memory errors.
+    let _dims = t.dims().unwrap();
+}


### PR DESCRIPTION
I can't get it to work for TerminfoTerm on windows (using the windows code reports the wrong values) so it is marked not supported.