### PR TITLE
win: Add WinConsoleInfo struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use std::io::prelude::*;
 
 pub use terminfo::TerminfoTerminal;
 #[cfg(windows)]
-pub use win::WinConsole;
+pub use win::{WinConsole, WinConsoleInfo};
 
 use std::io::{self, Stderr, Stdout};
 


### PR DESCRIPTION
 Parallel API to terminfo terminals is also added:
  * WinConsoleInfo::from_env()
  * WinConsole::new_with_consoleinfo()

 Just like terminfo, this allows to check if we are going to get
 errors before moving `out`.

 Related: #57