### PR TITLE
Pretend to be xterm if Windows console supports ansi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.2.1"
 dirs = "1.0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["wincon", "handleapi", "fileapi"] }
+winapi = { version = "0.3", features = ["consoleapi", "wincon", "handleapi", "fileapi"] }
 
 [features]
 default=[]

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -74,7 +74,7 @@ impl TermInfo {
 
         #[cfg(windows)]
         {
-            if term_name.is_none() && win::conout_supports_ansi() {
+            if term_name.is_none() && win::supports_ansi() {
                 // Microsoft people seem to be fine with pretending to be xterm:
                 // https://github.com/Microsoft/WSL/issues/1446
                 // The basic ANSI fallback terminal will be uses.

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -18,6 +18,10 @@ use std::io;
 use std::io::BufReader;
 use std::path::Path;
 
+
+#[cfg(windows)]
+use win;
+
 use Attr;
 use color;
 use Terminal;
@@ -67,6 +71,17 @@ impl TermInfo {
                 }
             })
         });
+
+        #[cfg(windows)]
+        {
+            if term_name.is_none() && win::conout_supports_ansi() {
+                // Microsoft people seem to be fine with pretending to be xterm:
+                // https://github.com/Microsoft/WSL/issues/1446
+                // The basic ANSI fallback terminal will be uses.
+                return TermInfo::from_name("xterm");
+            }
+        }
+
         if let Some(term_name) = term_name {
             return TermInfo::from_name(term_name);
         } else {

--- a/src/win.rs
+++ b/src/win.rs
@@ -24,7 +24,9 @@ use Result;
 use Terminal;
 use color;
 
-use win::winapi::um::wincon::{SetConsoleCursorPosition, SetConsoleTextAttribute, BACKGROUND_INTENSITY};
+use win::winapi::um::wincon::{SetConsoleCursorPosition, SetConsoleTextAttribute};
+use win::winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};
+use win::winapi::um::wincon::{ENABLE_VIRTUAL_TERMINAL_PROCESSING, BACKGROUND_INTENSITY};
 use win::winapi::um::wincon::{FillConsoleOutputCharacterW, GetConsoleScreenBufferInfo, COORD};
 use win::winapi::um::wincon::FillConsoleOutputAttribute;
 use win::winapi::shared::minwindef::{DWORD, WORD};
@@ -116,8 +118,7 @@ impl Deref for HandleWrapper {
     }
 }
 
-// Just get a handle to the current console buffer whatever it is
-fn conout() -> io::Result<HandleWrapper> {
+fn conout_with_flag(flag: Option<DWORD>) -> io::Result<HandleWrapper> {
     let name = b"CONOUT$\0";
     let handle = unsafe {
         CreateFileA(
@@ -133,8 +134,34 @@ fn conout() -> io::Result<HandleWrapper> {
     if handle == INVALID_HANDLE_VALUE {
         Err(io::Error::last_os_error())
     } else {
+        if let Some(flag) = flag {
+            let mut curr_mode: DWORD = 0;
+            unsafe {
+                if GetConsoleMode(handle, &mut curr_mode) == 0 {
+                    let err = Err(io::Error::last_os_error());
+                    drop(HandleWrapper::new(handle));
+                    return err;
+                }
+
+                if SetConsoleMode(handle, curr_mode | flag) == 0 {
+                    let err = Err(io::Error::last_os_error());
+                    drop(HandleWrapper::new(handle));
+                    return err;
+                }
+            }
+        }
         Ok(HandleWrapper::new(handle))
     }
+}
+
+/// Check if console supports ansi codes (should succeed on Windows 10)
+pub fn conout_supports_ansi() -> bool {
+    conout_with_flag(Some(ENABLE_VIRTUAL_TERMINAL_PROCESSING)).is_ok()
+}
+
+// Just get a handle to the current console buffer whatever it is
+fn conout() -> io::Result<HandleWrapper> {
+    conout_with_flag(None)
 }
 
 // This test will only pass if it is running in an actual console, probably


### PR DESCRIPTION
 Windows people seem to be fine with this:
 Microsoft/WSL#1446

 I still think a precise terminfo file with the list of
 supported sequences documented in the below link would be ideal:
 https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences

 But I didn't find such a file. And I don't know how to generate
 one easily.

~~A copy of xterm-256color terminfo file is included at compile-time.
 I copied it from ncurses 6.1.~~

 ~~With this commit, term should be on par with ansi_term for Windows 10
 users.~~

Edited to fallback to a basic ANSI terminal.