### PR TITLE
Remove byteorder-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ travis-ci = { repository = "Stebalien/term" }
 appveyor = { repository = "Stebalien/term" }
 
 [dependencies]
-byteorder = "1.2.1"
 dirs = "2.0.1"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/win.rs
+++ b/src/win.rs
@@ -13,14 +13,14 @@
 // FIXME (#13400): this is only a tiny fraction of the Windows console api
 
 use crate::color;
-use std::io;
-use std::io::prelude::*;
-use std::ops::Deref;
-use std::ptr;
 use crate::Attr;
 use crate::Error;
 use crate::Result;
 use crate::Terminal;
+use std::io;
+use std::io::prelude::*;
+use std::ops::Deref;
+use std::ptr;
 
 use winapi::shared::minwindef::{DWORD, WORD};
 use winapi::um::consoleapi::{GetConsoleMode, SetConsoleMode};


### PR DESCRIPTION
This removes the `byteorder`-dependency, which is unneeded since 1.32 and gets pulled in _a lot_ due to `term`.