### PR TITLE
Avoid installing old version in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! ```toml
 //! [dependencies]
 //!
-//! term = "0.4.6"
+//! term = "*"
 //! ```
 //!
 //! and this to your crate root:


### PR DESCRIPTION
While I was reading documentation of this crate, I noticed the installation guide shows older version. I updated it to `*` like README.md to prevent users accidentally installing older version by copy and paste.