### PR TITLE
Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "Stebalien/term" }
 appveyor = { repository = "Stebalien/term" }
 
 [dependencies]
-dirs = "2.0.1"
+dirs = "3.0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "wincon", "handleapi", "fileapi"] }

--- a/src/terminfo/mod.rs
+++ b/src/terminfo/mod.rs
@@ -206,11 +206,16 @@ pub enum Error {
 
 impl ::std::fmt::Display for Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        use std::error::Error;
         match *self {
-            NotUtf8(e) => write!(f, "{}", e),
             BadMagic(v) => write!(f, "bad magic number {:x} in terminfo header", v),
-            _ => f.write_str(self.description()),
+            ShortNames => f.write_str("no names exposed, need at least one"),
+            TooManyBools => f.write_str("more boolean properties than libterm knows about"),
+            TooManyNumbers => f.write_str("more number properties than libterm knows about"),
+            TooManyStrings => f.write_str("more string properties than libterm knows about"),
+            InvalidLength => f.write_str("invalid length field value, must be >= -1"),
+            NotUtf8(ref e) => e.fmt(f),
+            NamesMissingNull => f.write_str("names table missing NUL terminator"),
+            StringsMissingNull => f.write_str("string table missing NUL terminator"),
         }
     }
 }
@@ -222,21 +227,7 @@ impl ::std::convert::From<::std::string::FromUtf8Error> for Error {
 }
 
 impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            BadMagic(..) => "incorrect magic number at start of file",
-            ShortNames => "no names exposed, need at least one",
-            TooManyBools => "more boolean properties than libterm knows about",
-            TooManyNumbers => "more number properties than libterm knows about",
-            TooManyStrings => "more string properties than libterm knows about",
-            InvalidLength => "invalid length field value, must be >= -1",
-            NotUtf8(ref e) => e.description(),
-            NamesMissingNull => "names table missing NUL terminator",
-            StringsMissingNull => "string table missing NUL terminator",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             NotUtf8(ref e) => Some(e),
             _ => None,

--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -82,32 +82,25 @@ pub enum Error {
 
 impl ::std::fmt::Display for Error {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        use std::error::Error;
-        f.write_str(self.description())
-    }
-}
-
-impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
         use self::Error::*;
         match *self {
-            StackUnderflow => "not enough elements on the stack",
-            TypeMismatch => "type mismatch",
-            UnrecognizedFormatOption(_) => "unrecognized format option",
-            InvalidVariableName(_) => "invalid variable name",
-            InvalidParameterIndex(_) => "invalid parameter index",
-            MalformedCharacterConstant => "malformed character constant",
-            IntegerConstantOverflow => "integer constant computation overflowed",
-            MalformedIntegerConstant => "malformed integer constant",
-            FormatWidthOverflow => "format width constant computation overflowed",
-            FormatPrecisionOverflow => "format precision constant computation overflowed",
+            StackUnderflow => f.write_str("not enough elements on the stack"),
+            TypeMismatch => f.write_str("type mismatch"),
+            UnrecognizedFormatOption(_) => f.write_str("unrecognized format option"),
+            InvalidVariableName(_) => f.write_str("invalid variable name"),
+            InvalidParameterIndex(_) => f.write_str("invalid parameter index"),
+            MalformedCharacterConstant => f.write_str("malformed character constant"),
+            IntegerConstantOverflow => f.write_str("integer constant computation overflowed"),
+            MalformedIntegerConstant => f.write_str("malformed integer constant"),
+            FormatWidthOverflow => f.write_str("format width constant computation overflowed"),
+            FormatPrecisionOverflow => {
+                f.write_str("format precision constant computation overflowed")
+            }
         }
     }
-
-    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
-        None
-    }
 }
+
+impl ::std::error::Error for Error {}
 
 /// Container for static and dynamic variable arrays
 #[derive(Default)]


### PR DESCRIPTION
I noticed that in my dependency tree `term` was causing me to pull in an old version of `dirs`, so thought I'd send in a quick PR for that.

To satisfy `deny(warnings)` in the tests, I first had to update the `Error` implementations to deal with deprecations in that trait.