### PR TITLE
Change unmaintained dirs crate to dirs-next

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "Stebalien/term" }
 appveyor = { repository = "Stebalien/term" }
 
 [dependencies]
-dirs = "3.0.1"
+dirs-next = "2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "wincon", "handleapi", "fileapi"] }

--- a/src/terminfo/searcher.rs
+++ b/src/terminfo/searcher.rs
@@ -16,7 +16,7 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-use dirs;
+use dirs_next as dirs;
 
 /// Return path to database entry for `term`
 pub fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2020-0053

```
Crate:  dirs
Title:  dirs is unmaintained, use dirs-next instead
Date:   2020-10-16
URL:    https://rustsec.org/advisories/RUSTSEC-2020-0053
Dependency tree:
dirs 3.0.1
└── term 0.6.1
```