### PR TITLE
Make license metadata SPDX-formatted

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "term"
 version = "0.7.0"
 authors = ["The Rust Project Developers", "Steven Allen"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Stebalien/term"
 homepage = "https://github.com/Stebalien/term"


### PR DESCRIPTION
This makes the license metadata be in the standard SPDX format, so tools can correctly interpret the license metadata of this crate.