### PR TITLE
Make tests pass on Rust 1.53

### DIFF
--- a/src/terminfo/parm.rs
+++ b/src/terminfo/parm.rs
@@ -675,15 +675,15 @@ mod test {
         for &(op, bs) in &v {
             let s = format!("%{{1}}%{{2}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
-            assert!(res.is_ok(), res.err().unwrap());
+            assert!(res.is_ok(), "{}", res.err().unwrap());
             assert_eq!(res.unwrap(), vec![b'0' + bs[0]]);
             let s = format!("%{{1}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
-            assert!(res.is_ok(), res.err().unwrap());
+            assert!(res.is_ok(), "{}", res.err().unwrap());
             assert_eq!(res.unwrap(), vec![b'0' + bs[1]]);
             let s = format!("%{{2}}%{{1}}%{}%d", op);
             let res = expand(s.as_bytes(), &[], &mut Variables::new());
-            assert!(res.is_ok(), res.err().unwrap());
+            assert!(res.is_ok(), "{}", res.err().unwrap());
             assert_eq!(res.unwrap(), vec![b'0' + bs[2]]);
         }
     }
@@ -693,13 +693,13 @@ mod test {
         let mut vars = Variables::new();
         let s = b"\\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m";
         let res = expand(s, &[Number(1)], &mut vars);
-        assert!(res.is_ok(), res.err().unwrap());
+        assert!(res.is_ok(), "{}", res.err().unwrap());
         assert_eq!(res.unwrap(), "\\E[31m".bytes().collect::<Vec<_>>());
         let res = expand(s, &[Number(8)], &mut vars);
-        assert!(res.is_ok(), res.err().unwrap());
+        assert!(res.is_ok(), "{}", res.err().unwrap());
         assert_eq!(res.unwrap(), "\\E[90m".bytes().collect::<Vec<_>>());
         let res = expand(s, &[Number(42)], &mut vars);
-        assert!(res.is_ok(), res.err().unwrap());
+        assert!(res.is_ok(), "{}", res.err().unwrap());
         assert_eq!(res.unwrap(), "\\E[38;5;42m".bytes().collect::<Vec<_>>());
     }
 


### PR DESCRIPTION
Since all warnings are `deny`ed when `cfg(test)`, new warnings in rustc make tests fail. A new warning was added to rustc, so they fail with warnings like this:
```
error: panic message is not a string literal
   --> src/terminfo/parm.rs:682:34
    |
682 |             assert!(res.is_ok(), res.err().unwrap());
    |                                  ^^^^^^^^^^^^^^^^^^
    |
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
682 |             assert!(res.is_ok(), "{}", res.err().unwrap());
    |                                  ^^^^^
```

This fixes that by correcting the warnings, and tests now pass.