### PR TITLE
Fix links to badge image and CI workfklow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ term
 
 A Rust library for terminfo parsing and terminal colors.
 
-[![CI](https://github.com/Stebalien/term-crate/actions/workflows/ci.yml/badge.svg)](https://github.com/Stebalien/term-crate/actions/workflows/ci.yml)
+[![CI](https://github.com/Stebalien/term/actions/workflows/ci.yml/badge.svg)](https://github.com/Stebalien/term/actions/workflows/ci.yml)
 
 [Documentation](https://docs.rs/term/)
 


### PR DESCRIPTION
I'm sorry that links in the badge in readme was not correct. I wrongly put name of my fork repository.

This PR fixes the links.