### PR TITLE
Release 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.0.0"
 dependencies = [
  "home",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "term"
-version = "0.7.0"
+version = "1.0.0"
 authors = ["The Rust Project Developers", "Steven Allen"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This crate is defacto stable so we might as well move to 1.0.