### PR TITLE
Cap home dependency version below 5.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.63"
 
 [dependencies]
-home = "0.5.5"
+home = ">0.5.5, <0.5.11"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"


### PR DESCRIPTION
Home released version 5.11 bumping the msrv to rust 1.81.  They justify such an aggressive msrv policy by stating that users should not be using the home crate at all, but instead should rely on the standard library home_dir function.  That function has a bug that is not fixed until 1.85, which prevents it from being an option for lower rust versions.

To mitigate, just pin to an older home version for now.